### PR TITLE
refactor: centralize dashboard state with useReducer

### DIFF
--- a/src/components/controls/CSVInputs.jsx
+++ b/src/components/controls/CSVInputs.jsx
@@ -3,28 +3,28 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Upload, FileText, X } from "lucide-react";
 import { Button } from "../ui/button";
 
-export default function CSVInputs({ priceCSV, setPriceCSV, flowCSV, setFlowCSV }) {
+export default function CSVInputs({ priceCSV, flowCSV, dispatch }) {
   const [priceFileName, setPriceFileName] = useState("");
   const [flowFileName, setFlowFileName] = useState("");
-  
-  const handleFileUpload = (file, setter, fileNameSetter) => {
+
+  const handleFileUpload = (file, actionType, fileNameSetter) => {
     if (!file) return;
-    
+
     const reader = new FileReader();
     reader.onload = (e) => {
-      setter(e.target.result);
+      dispatch({ type: actionType, payload: e.target.result });
       fileNameSetter(file.name);
     };
     reader.readAsText(file);
   };
-  
+
   const clearPriceData = () => {
-    setPriceCSV("");
+    dispatch({ type: "SET_PRICE_CSV", payload: "" });
     setPriceFileName("");
   };
-  
+
   const clearFlowData = () => {
-    setFlowCSV("");
+    dispatch({ type: "SET_FLOW_CSV", payload: "" });
     setFlowFileName("");
   };
 
@@ -62,7 +62,7 @@ export default function CSVInputs({ priceCSV, setPriceCSV, flowCSV, setFlowCSV }
                   type="file"
                   className="hidden"
                   accept=".csv"
-                  onChange={(e) => handleFileUpload(e.target.files[0], setPriceCSV, setPriceFileName)}
+                  onChange={(e) => handleFileUpload(e.target.files[0], "SET_PRICE_CSV", setPriceFileName)}
                 />
               </label>
             )}
@@ -79,7 +79,7 @@ export default function CSVInputs({ priceCSV, setPriceCSV, flowCSV, setFlowCSV }
 ..."
                 value={priceCSV}
                 onChange={(e) => {
-                  setPriceCSV(e.target.value);
+                  dispatch({ type: "SET_PRICE_CSV", payload: e.target.value });
                   setPriceFileName("");
                 }}
               />
@@ -120,7 +120,7 @@ export default function CSVInputs({ priceCSV, setPriceCSV, flowCSV, setFlowCSV }
                   type="file"
                   className="hidden"
                   accept=".csv"
-                  onChange={(e) => handleFileUpload(e.target.files[0], setFlowCSV, setFlowFileName)}
+                  onChange={(e) => handleFileUpload(e.target.files[0], "SET_FLOW_CSV", setFlowFileName)}
                 />
               </label>
             )}
@@ -136,7 +136,7 @@ export default function CSVInputs({ priceCSV, setPriceCSV, flowCSV, setFlowCSV }
 2025-08-01,1200000000,-300000000..."
                 value={flowCSV}
                 onChange={(e) => {
-                  setFlowCSV(e.target.value);
+                  dispatch({ type: "SET_FLOW_CSV", payload: e.target.value });
                   setFlowFileName("");
                 }}
               />

--- a/src/components/controls/DataLoader.jsx
+++ b/src/components/controls/DataLoader.jsx
@@ -3,20 +3,20 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { RefreshCw, Database } from "lucide-react";
 
-export default function DataLoader({ setUseSample, setPriceCSV, setFlowCSV, setAnchorIndex }) {
+export default function DataLoader({ dispatch }) {
   const loadLocalData = async () => {
     try {
       // 가격 데이터 로드
       const priceResponse = await fetch('/price_data.csv');
       const priceText = await priceResponse.text();
-      setPriceCSV(priceText);
-      
+      dispatch({ type: "SET_PRICE_CSV", payload: priceText });
+
       // 수급 데이터 로드 (금액 단위)
       const flowResponse = await fetch('/flows_data.csv');
       const flowText = await flowResponse.text();
-      setFlowCSV(flowText);
-      
-      setAnchorIndex(0);
+      dispatch({ type: "SET_FLOW_CSV", payload: flowText });
+
+      dispatch({ type: "SET_ANCHOR_INDEX", payload: 0 });
     } catch (error) {
       console.error('데이터 로드 실패:', error);
       alert('데이터 로드에 실패했습니다. CSV 파일을 직접 업로드해주세요.');
@@ -28,14 +28,14 @@ export default function DataLoader({ setUseSample, setPriceCSV, setFlowCSV, setA
       // 가격 데이터 로드
       const priceResponse = await fetch('/price_data.csv');
       const priceText = await priceResponse.text();
-      setPriceCSV(priceText);
-      
+      dispatch({ type: "SET_PRICE_CSV", payload: priceText });
+
       // 수급 데이터 로드 (주식수 단위)
       const flowResponse = await fetch('/flows_volume.csv');
       const flowText = await flowResponse.text();
-      setFlowCSV(flowText);
-      
-      setAnchorIndex(0);
+      dispatch({ type: "SET_FLOW_CSV", payload: flowText });
+
+      dispatch({ type: "SET_ANCHOR_INDEX", payload: 0 });
       console.log('주식수 단위 데이터 로드 완료');
     } catch (error) {
       console.error('데이터 로드 실패:', error);
@@ -56,7 +56,7 @@ export default function DataLoader({ setUseSample, setPriceCSV, setFlowCSV, setA
           <Button variant="outline" onClick={loadVolumeData}>
             <Database className="w-4 h-4 mr-2"/>주식수 단위 로드
           </Button>
-          <Button variant="ghost" onClick={() => { setAnchorIndex(0); }}>
+          <Button variant="ghost" onClick={() => dispatch({ type: "SET_ANCHOR_INDEX", payload: 0 })}>
             <RefreshCw className="w-4 h-4 mr-2"/>VWAP 앵커 초기화
           </Button>
         </div>

--- a/src/components/controls/FlowDisplayOptions.jsx
+++ b/src/components/controls/FlowDisplayOptions.jsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { ALL_INVESTOR_CATEGORIES } from "../../constants/sampleData";
 
-export default function FlowDisplayOptions({ unitScale, setUnitScale, selectedCats, toggleCat }) {
+export default function FlowDisplayOptions({ unitScale, selectedCats, dispatch }) {
   return (
     <Card className="shadow-sm">
       <CardHeader>
@@ -12,14 +12,14 @@ export default function FlowDisplayOptions({ unitScale, setUnitScale, selectedCa
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2 text-sm">
           <span className="text-slate-500">단위:</span>
-          <Button variant={unitScale === 1 ? "default" : "secondary"} onClick={() => setUnitScale(1)}>원</Button>
-          <Button variant={unitScale === 1000000 ? "default" : "secondary"} onClick={() => setUnitScale(1000000)}>백만원</Button>
-          <Button variant={unitScale === 100000000 ? "default" : "secondary"} onClick={() => setUnitScale(100000000)}>억원</Button>
+          <Button variant={unitScale === 1 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_UNIT_SCALE", payload: 1 })}>원</Button>
+          <Button variant={unitScale === 1000000 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_UNIT_SCALE", payload: 1000000 })}>백만원</Button>
+          <Button variant={unitScale === 100000000 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_UNIT_SCALE", payload: 100000000 })}>억원</Button>
         </div>
         <div className="grid grid-cols-2 gap-2 text-sm">
           {ALL_INVESTOR_CATEGORIES.map((k) => (
             <label key={k} className="flex items-center gap-2">
-              <input type="checkbox" checked={selectedCats.includes(k)} onChange={() => toggleCat(k)} />
+              <input type="checkbox" checked={selectedCats.includes(k)} onChange={() => dispatch({ type: "TOGGLE_CATEGORY", payload: k })} />
               <span>{k}</span>
             </label>
           ))}

--- a/src/components/controls/PeriodSelector.jsx
+++ b/src/components/controls/PeriodSelector.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 
-export default function PeriodSelector({ days, setDays }) {
+export default function PeriodSelector({ days, dispatch }) {
   return (
     <Card className="shadow-sm">
       <CardHeader>
@@ -10,10 +10,10 @@ export default function PeriodSelector({ days, setDays }) {
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2">
-          <Button variant={days === 30 ? "default" : "secondary"} onClick={() => setDays(30)}>30일</Button>
-          <Button variant={days === 60 ? "default" : "secondary"} onClick={() => setDays(60)}>60일</Button>
-          <Button variant={days === 90 ? "default" : "secondary"} onClick={() => setDays(90)}>90일</Button>
-          <Button variant={days === 180 ? "default" : "secondary"} onClick={() => setDays(180)}>6개월</Button>
+          <Button variant={days === 30 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_DAYS", payload: 30 })}>30일</Button>
+          <Button variant={days === 60 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_DAYS", payload: 60 })}>60일</Button>
+          <Button variant={days === 90 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_DAYS", payload: 90 })}>90일</Button>
+          <Button variant={days === 180 ? "default" : "secondary"} onClick={() => dispatch({ type: "SET_DAYS", payload: 180 })}>6개월</Button>
         </div>
         <div className="text-xs text-slate-500">
           표본 데이터는 7/10~8/8을 포함합니다. 실제 트레이딩엔 반드시 최신 CSV를 로드하세요.

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -1,0 +1,40 @@
+import { useReducer } from "react";
+import { DEFAULT_SELECTED_CATEGORIES, DEFAULT_UNIT_SCALE } from "../constants/sampleData";
+
+const initialState = {
+  priceCSV: "",
+  flowCSV: "",
+  anchorIndex: 0,
+  days: 60,
+  useSample: false,
+  unitScale: DEFAULT_UNIT_SCALE,
+  selectedCats: DEFAULT_SELECTED_CATEGORIES,
+};
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "SET_PRICE_CSV":
+      return { ...state, priceCSV: action.payload };
+    case "SET_FLOW_CSV":
+      return { ...state, flowCSV: action.payload };
+    case "SET_ANCHOR_INDEX":
+      return { ...state, anchorIndex: action.payload };
+    case "SET_DAYS":
+      return { ...state, days: action.payload };
+    case "SET_USE_SAMPLE":
+      return { ...state, useSample: action.payload };
+    case "SET_UNIT_SCALE":
+      return { ...state, unitScale: action.payload };
+    case "TOGGLE_CATEGORY":
+      return state.selectedCats.includes(action.payload)
+        ? { ...state, selectedCats: state.selectedCats.filter((k) => k !== action.payload) }
+        : { ...state, selectedCats: [...state.selectedCats, action.payload] };
+    default:
+      return state;
+  }
+}
+
+export function useDashboardState() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return { state, dispatch };
+}

--- a/src/paradise_flow_dashboard_interactive.jsx
+++ b/src/paradise_flow_dashboard_interactive.jsx
@@ -1,13 +1,13 @@
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useMemo, useCallback } from "react";
 import { motion } from "framer-motion";
 import { LineChart as LineChartIcon } from "lucide-react";
 import { Button } from "./components/ui/button";
 import { TooltipProvider } from "./components/ui/tooltip";
 
 // Utilities
-import { DEFAULT_SELECTED_CATEGORIES, DEFAULT_UNIT_SCALE } from "./constants/sampleData";
 import { useDataProcessing } from "./hooks/useDataProcessing";
 import { useSelfTest } from "./hooks/useSelfTest";
+import { useDashboardState } from "./hooks/useDashboardState";
 
 // Components
 import PeriodSelector from "./components/controls/PeriodSelector";
@@ -26,13 +26,16 @@ import TradingSignalPanel from "./components/TradingSignalPanel";
 
 export default function ParadiseFlowDashboard() {
   // State management
-  const [priceCSV, setPriceCSV] = useState("");
-  const [flowCSV, setFlowCSV] = useState("");
-  const [anchorIndex, setAnchorIndex] = useState(0);
-  const [days, setDays] = useState(60);
-  const [useSample, setUseSample] = useState(false);
-  const [unitScale, setUnitScale] = useState(DEFAULT_UNIT_SCALE);
-  const [selectedCats, setSelectedCats] = useState(DEFAULT_SELECTED_CATEGORIES);
+  const { state, dispatch } = useDashboardState();
+  const {
+    priceCSV,
+    flowCSV,
+    anchorIndex,
+    days,
+    useSample,
+    unitScale,
+    selectedCats,
+  } = state;
 
   // Custom hooks
   const { enriched } = useDataProcessing(priceCSV, flowCSV, useSample, anchorIndex);
@@ -67,15 +70,14 @@ export default function ParadiseFlowDashboard() {
   ), [unitScale]);
 
   // Event handlers
-  const toggleCat = useCallback((k) => {
-    setSelectedCats((prev) => (prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]));
-  }, []);
-
   const handleChartClick = useCallback((e) => {
     if (e && e.activeTooltipIndex != null) {
-      setAnchorIndex(enriched.indexOf(viewData[e.activeTooltipIndex]));
+      dispatch({
+        type: "SET_ANCHOR_INDEX",
+        payload: enriched.indexOf(viewData[e.activeTooltipIndex]),
+      });
     }
-  }, [enriched, viewData]);
+  }, [dispatch, enriched, viewData]);
 
   return (
     <TooltipProvider>
@@ -96,28 +98,17 @@ export default function ParadiseFlowDashboard() {
 
         {/* Controls */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <PeriodSelector days={days} setDays={setDays} />
-          <DataLoader 
-            setUseSample={setUseSample} 
-            setPriceCSV={setPriceCSV} 
-            setFlowCSV={setFlowCSV} 
-            setAnchorIndex={setAnchorIndex} 
-          />
-          <FlowDisplayOptions 
-            unitScale={unitScale} 
-            setUnitScale={setUnitScale} 
-            selectedCats={selectedCats} 
-            toggleCat={toggleCat} 
+          <PeriodSelector days={days} dispatch={dispatch} />
+          <DataLoader dispatch={dispatch} />
+          <FlowDisplayOptions
+            unitScale={unitScale}
+            selectedCats={selectedCats}
+            dispatch={dispatch}
           />
         </div>
 
           {/* CSV inputs */}
-          <CSVInputs 
-            priceCSV={priceCSV} 
-            setPriceCSV={setPriceCSV} 
-            flowCSV={flowCSV} 
-            setFlowCSV={setFlowCSV} 
-          />
+          <CSVInputs priceCSV={priceCSV} flowCSV={flowCSV} dispatch={dispatch} />
 
           {/* Trading Signal Panel - 최우선 표시 */}
           <TradingSignalPanel data={viewData} />


### PR DESCRIPTION
## Summary
- consolidate dashboard state into a reducer via `useDashboardState`
- update controls and dashboard component to dispatch actions
- wire CSV inputs and data loader to reducer-managed state

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6897fa574a40832e845a4ea6eb02ed13